### PR TITLE
Scipy greater than 181

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -243,14 +243,14 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "awscli"
-version = "1.25.12"
+version = "1.25.13"
 description = "Universal Command Line Environment for AWS."
 category = "dev"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = "1.27.12"
+botocore = "1.27.13"
 colorama = ">=0.2.5,<0.4.5"
 docutils = ">=0.10,<0.17"
 PyYAML = ">=3.10,<5.5"
@@ -319,7 +319,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "botocore"
-version = "1.27.12"
+version = "1.27.13"
 description = "Low-level, data-driven core of boto 3."
 category = "dev"
 optional = false
@@ -3216,8 +3216,8 @@ attrs = [
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 awscli = [
-    {file = "awscli-1.25.12-py3-none-any.whl", hash = "sha256:f6b929879ef43b9e7eb8e1c26eced7852ccff01cd28c5ba932be16f51812495b"},
-    {file = "awscli-1.25.12.tar.gz", hash = "sha256:166f4404c57da29c2e620350080349225ef60277592810fbc812e0304c045173"},
+    {file = "awscli-1.25.13-py3-none-any.whl", hash = "sha256:e290e54b918c04d9cc45d99bb630ec07afc19586109da50f818dd1c95df356c6"},
+    {file = "awscli-1.25.13.tar.gz", hash = "sha256:18a23dd9b39e9545ca787f3760ccb05644ced56c7a17c6df5b62f4f31f85d7c0"},
 ]
 babel = [
     {file = "Babel-2.10.3-py3-none-any.whl", hash = "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"},
@@ -3257,8 +3257,8 @@ black = [
     {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
 ]
 botocore = [
-    {file = "botocore-1.27.12-py3-none-any.whl", hash = "sha256:b8ac156e55267da6e728ea0b806bfcd97adf882801cffe7849c4b88ce4780326"},
-    {file = "botocore-1.27.12.tar.gz", hash = "sha256:17d3ec9f684d21e06b64d9cb224934557bcd95031e2ecb551bf16271e8722fec"},
+    {file = "botocore-1.27.13-py3-none-any.whl", hash = "sha256:fbc09558c02d415e8646520f95db7e8d313460938780fa6040b00865f098fd55"},
+    {file = "botocore-1.27.13.tar.gz", hash = "sha256:df75e53576b061818bbce4bd70221749e40cc91d16a2b6c03fbeec8023665734"},
 ]
 cachetools = [
     {file = "cachetools-4.2.4-py3-none-any.whl", hash = "sha256:92971d3cb7d2a97efff7c7bb1657f21a8f5fb309a37530537c71b1774189f2d1"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -3051,7 +3051,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.*"
-content-hash = "5a6096d5e5315b3650bf097242d08d4c10acd3508cf8f54ae27d25f12bb8646e"
+content-hash = "49e671f29e8560bbf40c0e93740e9c7a199c960c354eab305c9d231736d1a5ad"
 
 [metadata.files]
 absl-py = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ numpy = "^1.21.6"
 pandas = "^1.3.5"
 scikit-learn = "^1.0.2"
 nltk = "^3.7"
-scipy = "^1.7.3"
+scipy = "^1.8.1"
 markupsafe = "^2.1.1"
 fastapi = "^0.78.0"
 uvicorn = {extras = ["standard"], version = "^0.17.6"}


### PR DESCRIPTION
Scipy renamed a module. 

https://github.com/scipy/scipy/commit/f84b8039ac9cc9cee1144958d05db750ac8e9dee

This caused problems with pickling data.

https://github.com/scipy/scipy/commit/f84b8039ac9cc9cee1144958d05db750ac8e9dee

That's why we pinned the Python version to 3.9 and now also require scipy to be higher than 1.8.1.